### PR TITLE
Preserve default click behavior

### DIFF
--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -4,9 +4,7 @@
 // smooth scroll
 
 $(document).on('click', 'a[href^="#"]', function (event) {
-    event.preventDefault();
-
-    $('html, body').animate({
-      scrollTop: $($.attr(this, 'href')).offset().top
-    }, 500);
+  $('html, body').animate({
+    scrollTop: $($.attr(this, 'href')).offset().top
+  }, 500);
 });


### PR DESCRIPTION
The call to `event.preventDefault()` was blocking some of the default Slate behavior that populates the address bar with the currently clicked URL and blocking the browser history pushState behavior