### PR TITLE
Change cURL commands

### DIFF
--- a/source/includes/rest/_batch_api.md
+++ b/source/includes/rest/_batch_api.md
@@ -6,6 +6,7 @@
 
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/subscribers/batches" \
+  -H 'Content-Type: applicaton/json' \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
   -u YOUR_API_KEY: \
   -d @- << EOF
@@ -124,6 +125,7 @@ request and the time your data appears in the user interface.
 
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/unsubscribes/batches" \
+  -H 'Content-Type: applicaton/json' \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
   -u YOUR_API_KEY: \
   -d @- << EOF
@@ -224,6 +226,7 @@ client.unsubscribeBatchSubscribers(payload)
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/subscribers/batches" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {
@@ -334,6 +337,7 @@ request and the time your data appears in the user interface.
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/orders/batches" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {

--- a/source/includes/rest/_campaigns.md
+++ b/source/includes/rest/_campaigns.md
@@ -520,6 +520,7 @@ client.listAllSubscribesToCampaign(campaignId)
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/campaigns/CAMPAIGN_ID/subscribers" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {

--- a/source/includes/rest/_events.md
+++ b/source/includes/rest/_events.md
@@ -7,6 +7,7 @@
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/events" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {

--- a/source/includes/rest/_orders.md
+++ b/source/includes/rest/_orders.md
@@ -368,6 +368,7 @@
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/orders" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {
@@ -752,6 +753,7 @@ To update an existing order, include the <code>provider</code> and <code>upstrea
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/refunds" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {

--- a/source/includes/rest/_subscribers.md
+++ b/source/includes/rest/_subscribers.md
@@ -142,6 +142,7 @@
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/subscribers" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {

--- a/source/includes/rest/_tags.md
+++ b/source/includes/rest/_tags.md
@@ -86,6 +86,7 @@ None.
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/tags" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {

--- a/source/includes/rest/_webhooks.md
+++ b/source/includes/rest/_webhooks.md
@@ -304,7 +304,7 @@ client.createWebhook(payload)
     </tr>
     <tr>
       <td><code>events</code></td>
-      <td>Optional. An Array specifiying which events we should send notifications for. Eligible events can be found in the <a href="#webhook-events">webhooks documentation</a>. By default, we will send notifications for all events except <code>subscrber.received_email</code>.</td>
+      <td>Optional. An Array specifiying which events we should send notifications for. Eligible events can be found in the <a href="#webhook-events">webhooks documentation</a>. By default, we will send notifications for all events except <code>subscriber.received_email</code>.</td>
     </tr>
   </tbody>
 </table>

--- a/source/includes/rest/_webhooks.md
+++ b/source/includes/rest/_webhooks.md
@@ -198,6 +198,7 @@ None.
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/webhooks" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {

--- a/source/includes/rest/_workflows.md
+++ b/source/includes/rest/_workflows.md
@@ -318,6 +318,7 @@ None.
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/workflows/WORKFLOW_ID/subscribers" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {
@@ -571,6 +572,7 @@ None.
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/workflows/WORKFLOW_ID/triggers" \
   -H 'User-Agent: Your App Name (www.yourapp.com)' \
+  -H 'Content-Type: applicaton/json' \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {


### PR DESCRIPTION
It would appear that our API is often happier with cURL commands if they carry the '-H "Content-Type: application/json" flag, it removes extra ```"``` and ```\"``` that should not be there and are thus not allowing actions to be interpreted correctly. 