### PR TITLE
Fix curl example bug with missing content type

### DIFF
--- a/source/includes/rest/_subscribers.md
+++ b/source/includes/rest/_subscribers.md
@@ -146,19 +146,20 @@
 
 ```shell
 curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/subscribers" \
-  -H 'User-Agent: Your App Name (www.yourapp.com)' \
-  -u YOUR_API_KEY: \
-  -d @- << EOF
-  {
-    "subscribers": [{
-      "email": "john@acme.com",
-      "time_zone": "America/Los_Angeles",
-      "custom_fields": {
-        "name": "John Doe"
-      }
-    }]
-  }
-  EOF
+-H 'User-Agent: Your App Name (www.yourapp.com)' \
+-H 'Content-Type: application/json' \
+-u YOUR_API_KEY: \
+-d @- << EOF
+{
+  "subscribers": [{
+    "email": "john@acme.com",
+    "time_zone": "America/Los_Angeles",
+    "custom_fields": {
+      "name": "John Doe"
+    }
+  }]
+}
+EOF
 ```
 
 ```ruby


### PR DESCRIPTION
Added missing content type and unindented so that copy/pasted example actually works (HEREDOC ending has to be on beginning of line).

In response to some customer comments in Slack.