### PR TITLE
DE-2072 clarify identifiers

### DIFF
--- a/source/includes/shopper_activity/_cart_activity.md
+++ b/source/includes/shopper_activity/_cart_activity.md
@@ -21,8 +21,8 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
     "cart_id": "456445746",
     "occurred_at": "2019-01-17T20:50:00Z",
     "cart_public_id": "#5",
-    "grand_total": 1699,
-    "total_discounts": 534,
+    "grand_total": 16.99,
+    "total_discounts": 5.34,
     "currency": "USD",
     "cart_url": "https://mysuperstore.com/cart/456445746",
     "items": [
@@ -37,8 +37,8 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
         ],
         "price": 11.16,
         "quantity": 2,
-        "discount": 534,
-        "total": 1699,
+        "discount": 5.34,
+        "total": 16.99,
         "product_url": "https://mysuperstore.com/dp/B01J4SWO1G",
         "image_url": "https://www.getdrip.com/images/example_products/water_bottle.png",
         "product_tag": "Best Seller"
@@ -100,11 +100,11 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
     </tr>
     <tr>
       <td><code>grand_total</code></td>
-      <td>Optional. The total amount of the cart in cents (e.g. if the order was $16.99, set the amount to 1699). This should include any applicable discounts. Defaults to 0.</td>
+      <td>Optional. The total amount of the cart. This should include any applicable discounts. Defaults to 0.</td>
     </tr>
     <tr>
       <td><code>total_discounts</code></td>
-      <td>Optional. The discount on the entire order in cents (e.g. if the discount was $5.34, set the discount to 534). Defaults to 0.</td>
+      <td>Optional. The discount on the entire order. Defaults to 0.</td>
     </tr>
     <tr>
       <td><code>currency</code></td>
@@ -153,7 +153,7 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
             </tr>
             <tr>
               <td><code>price</code></td>
-              <td>Required. The price of a single product (in cents).</td>
+              <td>Required. The price of a single product.</td>
             </tr>
             <tr>
               <td><code>quantity</code></td>
@@ -161,11 +161,11 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
             </tr>
             <tr>
               <td><code>discount</code></td>
-              <td>Optional. The discount on the item (in cents), taking quantity into account. For example, a $2.66 discount per item would be $5.34 (or 534) if that item was of quantity 2. Defaults to 0.</td>
+              <td>Optional. The discount on the items, taking quantity into account. For example, a $2.66 discount per item would be $5.34 if that item was of quantity 2. Defaults to 0.</td>
             </tr>
             <tr>
               <td><code>total</code></td>
-              <td>Optional. The line item total after quantity and discount (in cents). Defaults to 0.</td>
+              <td>Optional. The line item total after quantity and discount. Defaults to 0.</td>
             </tr>
             <tr>
               <td><code>product_url</code></td>

--- a/source/includes/shopper_activity/_cart_activity.md
+++ b/source/includes/shopper_activity/_cart_activity.md
@@ -2,7 +2,7 @@
 
 Passing in all required fields for Cart Activity will enable Cart Abandonment Dynamic Content in your Drip account. Leverage that content in our Visual Email Builder to send Cart Abandonment emails containing item details.
 
-Note that Cart Activity will show up on a person's activity timeline as either a "Created a cart" or "Updated a cart" event.
+Note that Cart Activity will show up on a person's activity timeline as either a "Created a cart" or "Updated a cart" event. For more information, see our Knowledge Base [here](https://help.drip.com/hc/en-us/articles/360022922031).
 
 ## Create or update a cart
 
@@ -16,7 +16,6 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
   -d @- << EOF
   {
     "provider": "magento",
-    "person_id": "suisqegbkv9zcfe8zsox",
     "email": "user@gmail.com",
     "action": "created",
     "cart_id": "456445746",
@@ -36,7 +35,7 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
         "categories": [
           "Accessories"
         ],
-        "price": 1116,
+        "price": 11.16,
         "quantity": 2,
         "discount": 534,
         "total": 1699,
@@ -77,11 +76,11 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
     </tr>
     <tr>
       <td><code>person_id</code></td>
-      <td>Optional. The unique identifier of a person at Drip. Either <code>person_id</code> or <code>email</code> must be included.</td>
+      <td>Optional. The unique identifier of a person at Drip. Either <code>person_id</code> or <code>email</code> must be included. If both are included, <code>email</code> is ignored.</td>
     </tr>
     <tr>
       <td><code>email</code></td>
-      <td>Optional. The person's email address. Either <code>person_id</code> or <code>email</code> must be included.</td>
+      <td>Optional. The person's email address. Either <code>person_id</code> or <code>email</code> must be included. If both are included, <code>email</code> is ignored.</td>
     </tr>
     <tr>
       <td><code>action</code></td>
@@ -186,5 +185,3 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
 The API will also allow custom attributes to be passed in. These will be exposed within Drip just like [event properties](https://help.drip.com/hc/en-us/articles/115003737312-Event-Properties).
 
 For example, if your platform includes the concept of product tags, you can include a product_tag attribute in the JSON that can be used in a Drip automation or email [via Liquid](https://help.drip.com/hc/en-us/articles/115003737312-Event-Properties#access-properties). You can attach custom attributes either to event (top level object) or items. Custom attribute values must be strings.
-
-For more information, see our Knowledge Base [here](https://help.drip.com/hc/en-us/articles/360022922031).


### PR DESCRIPTION
https://dripcom.atlassian.net/browse/DE-2072

A few more docs updates, per @bfortune347:
1) Clarify that `email` is ignored when sent with a `person_id`.
2) Move the sentence about the KB to the right spot.
3) Remove stuff about cents.