### PR TITLE
state which values are required for items

### DIFF
--- a/source/includes/rest/_orders.md
+++ b/source/includes/rest/_orders.md
@@ -284,7 +284,7 @@
     <tr>
       <td><code>items</code></td>
       <td>
-        An Array of objects containing information about specific order items.
+        Optional. An Array of objects containing information about specific order items.
         <br><br>
         <table>
           <thead>
@@ -296,11 +296,11 @@
           <tbody>
             <tr>
               <td><code>name</code></td>
-              <td>The product name</td>
+              <td>Required. The product name</td>
             </tr>
             <tr>
               <td><code>amount</code></td>
-              <td>The line total (in cents).</td>
+              <td>Required. The line total (in cents).</td>
             </tr>
             <tr>
               <td><code>price</code></td>


### PR DESCRIPTION
Customer had issues with orders containing items not being accepted by our order batch api. Turns our there are some required columns _if_ you have an array of items. Updating the api docs to reflect those validations