### PR TITLE
put optional/requireds in the right spot

### DIFF
--- a/source/includes/rest/_orders.md
+++ b/source/includes/rest/_orders.md
@@ -284,7 +284,7 @@
     <tr>
       <td><code>items</code></td>
       <td>
-        Optional. An Array of objects containing information about specific order items.
+        An Array of objects containing information about specific order items.
         <br><br>
         <table>
           <thead>
@@ -296,11 +296,11 @@
           <tbody>
             <tr>
               <td><code>name</code></td>
-              <td>Required. The product name</td>
+              <td>The product name</td>
             </tr>
             <tr>
               <td><code>amount</code></td>
-              <td>Required. The line total (in cents).</td>
+              <td>The line total (in cents).</td>
             </tr>
             <tr>
               <td><code>price</code></td>
@@ -767,11 +767,11 @@ To update an existing order, include the <code>provider</code> and <code>upstrea
           <tbody>
             <tr>
               <td><code>name</code></td>
-              <td>The product name</td>
+              <td>Required. The product name</td>
             </tr>
             <tr>
               <td><code>amount</code></td>
-              <td>The line total (in cents).</td>
+              <td>Required. The line total (in cents).</td>
             </tr>
             <tr>
               <td><code>price</code></td>


### PR DESCRIPTION
I accidentally put the `Optional/Required` updates on the `GET` description instead of the `POST` on this PR https://github.com/DripEmail/api-docs/pull/48 😬 

This fixes that
