### PR TITLE
Mark product_variant_id as required [DE-3035]

### DIFF
--- a/source/includes/shopper_activity/_cart_activity.md
+++ b/source/includes/shopper_activity/_cart_activity.md
@@ -180,7 +180,7 @@ end
             </tr>
             <tr>
               <td><code>product_variant_id</code></td>
-              <td>Optional. If applicable, a unique identifier for the specific product variant from the provider. For example, a t-shirt may have one product_id, but several product_variant_ids for sizes and colors.</td>
+              <td>Required. If applicable, a unique identifier for the specific product variant from the provider. For example, a t-shirt may have one product_id, but several product_variant_ids for sizes and colors. If a product does not have multiple variants and you do not have a variant identifier in your system, repeat the product_id here. (Note: this field is used by segmentation.)</td>
             </tr>
             <tr>
               <td><code>sku</code></td>

--- a/source/includes/shopper_activity/_order_activity.md
+++ b/source/includes/shopper_activity/_order_activity.md
@@ -262,7 +262,7 @@ end
             </tr>
             <tr>
               <td><code>product_variant_id</code></td>
-              <td>Optional. If applicable, a unique identifier for the specific product variant from the provider. For example, a t-shirt may have one product_id, but several product_variant_ids for sizes and colors.</td>
+              <td>Required. If applicable, a unique identifier for the specific product variant from the provider. For example, a t-shirt may have one product_id, but several product_variant_ids for sizes and colors. If a product does not have multiple variants and you do not have a variant identifier in your system, repeat the product_id here. (Note: this field is used by segmentation.)</td>
             </tr>
             <tr>
               <td><code>sku</code></td>

--- a/source/includes/shopper_activity/_product_activity.md
+++ b/source/includes/shopper_activity/_product_activity.md
@@ -107,7 +107,7 @@ end
     </tr>
     <tr>
       <td><code>product_variant_id</code></td>
-      <td>Optional. If applicable, a unique identifier for the specific product variant from the provider. For example, a t-shirt may have one product_id, but several product_variant_ids for sizes and colors.</td>
+      <td>Required. A unique identifier for the specific product variant from the provider. For example, a t-shirt may have one product_id, but several product_variant_ids for sizes and colors. If a product does not have multiple variants and you do not have a variant identifier in your system, repeat the product_id here. (Note: this field is used by segmentation.)</td>
     </tr>
     <tr>
       <td><code>sku</code></td>


### PR DESCRIPTION
We've realized that we are using `product_variant_id` as the internal primary key for segmentation, but we didn't make it required. Start by marking it as required in the documentation.