### PR TITLE
Document reserved `drip_` identify parameter namespace

### DIFF
--- a/source/includes/js/_identify.md
+++ b/source/includes/js/_identify.md
@@ -20,7 +20,7 @@ The `identify` method pushes subscriber data into Drip. If the subscriber is not
 
 ### Properties
 
-The following are treated as special properties. All other data passed in will be added to the subscriber's custom fields. Keys should be lowercase, with words separated by underscores.
+The following are treated as special properties. All other data passed in will be added to the subscriber's custom fields. Keys should be lowercase, with words separated by underscores. Keys that begin with <code>drip_</code> are reserved for internal Drip usage.
 
 <table>
   <thead>
@@ -69,6 +69,10 @@ The following are treated as special properties. All other data passed in will b
     <tr>
       <td><code>failure</code></td>
       <td>Optional. A callback function that is executed if the request fails.</td>
+    </tr>
+    <tr>
+      <td><code>drip_unknown_status</code></td>
+      <td>Optional. A Boolean specifying whether the identified Subscriber should be subscribed (<code>false</code>) or pending subscription (<code>true</code>).
     </tr>
   </tbody>
 </table>

--- a/source/includes/js/_identify.md
+++ b/source/includes/js/_identify.md
@@ -70,10 +70,6 @@ The following are treated as special properties. All other data passed in will b
       <td><code>failure</code></td>
       <td>Optional. A callback function that is executed if the request fails.</td>
     </tr>
-    <tr>
-      <td><code>drip_unknown_status</code></td>
-      <td>Optional. A Boolean specifying whether the identified Subscriber should be subscribed (<code>false</code>) or pending subscription (<code>true</code>).
-    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Make note `drip_` parameter rule, too.

<img width="945" alt="Screen_Shot_2019-08-20_at_10_20_06_AM" src="https://user-images.githubusercontent.com/1396405/63360656-6020f880-c334-11e9-9e65-9587a8880404.png">

