### PR TITLE
[ECI-1047] remove info about checking status of requests with request ids from dev docs

### DIFF
--- a/source/includes/shopper_activity/_cart_activity.md
+++ b/source/includes/shopper_activity/_cart_activity.md
@@ -97,7 +97,7 @@ else
 end
 ```
 
-> Responds with a <code>202 Accepted</code> if successful. That means the server accepted the request and queued it for processing. The response includes a unique request_id that can be used to check the status of the request later on:
+> Responds with a <code>202 Accepted</code> if successful. That means the server accepted the request and queued it for processing.
 
 ```json
 {

--- a/source/includes/shopper_activity/_order_activity.md
+++ b/source/includes/shopper_activity/_order_activity.md
@@ -165,7 +165,7 @@ else
 end
 ```
 
-> Responds with a <code>202 Accepted</code> if successful. That means the server accepted the request and queued it for processing. The response includes a unique request_id that can be used to check the status of the request later on:
+> Responds with a <code>202 Accepted</code> if successful. That means the server accepted the request and queued it for processing
 
 ```json
 {

--- a/source/includes/shopper_activity/_product_activity.md
+++ b/source/includes/shopper_activity/_product_activity.md
@@ -67,7 +67,7 @@ else
 end
 ```
 
-> Responds with a <code>202 Accepted</code> if successful. That means the server accepted the request and queued it for processing. The response includes a unique request_id that can be used to check the status of the request later on:
+> Responds with a <code>202 Accepted</code> if successful. That means the server accepted the request and queued it for processing.
 
 ```json
 {


### PR DESCRIPTION
Addresses: [ECI-1047](https://dripcom.atlassian.net/browse/ECI-1047)

Followup to: https://github.com/DripEmail/api-docs/pull/82

## Background
In the api-docs repo, from the section about a successful Shopper
Activity response, remove the part about checking the status of
request IDs.

## Modification

Just removed "The response includes a list of unique request_ids
that can be used to check the status of the request later on" text
from: 
source/includes/shopper_activity/_cart_activity.md
source/includes/shopper_activity/_order_activity.md
source/includes/shopper_activity/_product_activity.md