### PR TITLE
Rollback rack from 2.2.3 to 2.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     parallel (1.10.0)
     ptools (1.3.5)
     public_suffix (2.0.5)
-    rack (2.2.3)
+    rack (2.0.1)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)


### PR DESCRIPTION
Followup to: https://github.com/DripEmail/api-docs/pull/83

## Background

The new version of the rack had problems with the linter.
The validation of the Content-Length header was incorrect.

## Modification

Rollback rack from 2.2.3 to 2.0.1