### PR TITLE
SMS-435 Add sms_number and sms_consent to Subscribers API

### DIFF
--- a/source/includes/rest/_errors.md
+++ b/source/includes/rest/_errors.md
@@ -74,6 +74,10 @@ If validation errors occur while attempting to create or update a resource, you 
       <td>The attribute must be a valid email address.</td>
     </tr>
     <tr>
+      <td><code>sms_error</code></td>
+      <td>The attribute must be a valid US mobile number with E.164 formatting. E.g. <code>"+16125551212"</code>.</td>
+    </tr>
+    <tr>
       <td><code>url_error</code></td>
       <td>The attribute must be a valid URL.</td>
     </tr>

--- a/source/includes/rest/_subscribers.md
+++ b/source/includes/rest/_subscribers.md
@@ -121,11 +121,11 @@ On January 7, 2019 we renamed Subscribers to People to better represent who you�
     </tr>
     <tr>
       <td><code>sms_number</code></td>
-      <td>The subscriber's mobile phone number in E.164 formatting.</td>
+      <td>Optional. String. The subscriber's mobile phone number in E.164 formatting. E.g. <code>"+16125551212"</code>. Only US-based numbers are supported at this time.</td>
     </tr>
     <tr>
       <td><code>sms_consent</code></td>
-      <td>A boolean describing whether the person has granted consent to receive marketing and other communication via SMS.</td>
+      <td>Optional. Boolean. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. Default: false. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
     </tr>
     <tr>
       <td><code>eu_consent</code></td>
@@ -357,7 +357,7 @@ If you need to create or update a collection of subscribers at once, use our [ba
     </tr>
     <tr>
       <td><code>sms_consent</code></td>
-      <td>Optional. Boolean. Required if <code>sms_number</code> is not <code>null</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
+      <td>Optional. Boolean. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. Default: false. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
     </tr>
     <tr>
       <td><code>user_id</code></td>

--- a/source/includes/rest/_subscribers.md
+++ b/source/includes/rest/_subscribers.md
@@ -16,6 +16,8 @@
   "zip": "90210",
   "country": "US",
   "phone": "555-555-5555",
+  "sms_phone_number": "+16125551212",
+  "sms_consent": true,
   "eu_consent": "granted",
   "time_zone": "America/Los_Angeles",
   "utc_offset": -440,
@@ -116,6 +118,14 @@ On January 7, 2019 we renamed Subscribers to People to better represent who youâ
     <tr>
       <td><code>phone</code></td>
       <td>The subscriber's primary phone number.</td>
+    </tr>
+    <tr>
+      <td><code>sms_phone_number</code></td>
+      <td>The subscriber's mobile phone number in E.164 formatting.</td>
+    </tr>
+    <tr>
+      <td><code>sms_consent</code></td>
+      <td>A boolean describing whether the person has granted SMS consent.</td>
     </tr>
     <tr>
       <td><code>eu_consent</code></td>
@@ -340,6 +350,14 @@ If you need to create or update a collection of subscribers at once, use our [ba
     <tr>
       <td><code>phone</code></td>
       <td>Optional. The subscriber's primary phone number.</td>
+    </tr>
+    <tr>
+      <td><code>sms_phone_number</code></td>
+      <td>Optional. String. The subscriber's mobile phone number in E.164 formatting. E.g. <code>"+16125551212"</code>. Only US-based numbers are supported at this time.</td>
+    </tr>
+    <tr>
+      <td><code>sms_consent</code></td>
+      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>nil</code>. <code>true</code> if the person has granted SMS consent; <code>false</code> otherwise. If youâ€™re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
     </tr>
     <tr>
       <td><code>user_id</code></td>

--- a/source/includes/rest/_subscribers.md
+++ b/source/includes/rest/_subscribers.md
@@ -357,7 +357,7 @@ If you need to create or update a collection of subscribers at once, use our [ba
     </tr>
     <tr>
       <td><code>sms_consent</code></td>
-      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>nil</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
+      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>null</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
     </tr>
     <tr>
       <td><code>user_id</code></td>

--- a/source/includes/rest/_subscribers.md
+++ b/source/includes/rest/_subscribers.md
@@ -125,7 +125,7 @@ On January 7, 2019 we renamed Subscribers to People to better represent who you�
     </tr>
     <tr>
       <td><code>sms_consent</code></td>
-      <td>A boolean describing whether the person has granted SMS consent.</td>
+      <td>A boolean describing whether the person has granted consent to receive marketing and other communication via SMS.</td>
     </tr>
     <tr>
       <td><code>eu_consent</code></td>
@@ -357,7 +357,7 @@ If you need to create or update a collection of subscribers at once, use our [ba
     </tr>
     <tr>
       <td><code>sms_consent</code></td>
-      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>nil</code>. <code>true</code> if the person has granted SMS consent; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
+      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>nil</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
     </tr>
     <tr>
       <td><code>user_id</code></td>

--- a/source/includes/rest/_subscribers.md
+++ b/source/includes/rest/_subscribers.md
@@ -16,7 +16,7 @@
   "zip": "90210",
   "country": "US",
   "phone": "555-555-5555",
-  "sms_phone_number": "+16125551212",
+  "sms_number": "+16125551212",
   "sms_consent": true,
   "eu_consent": "granted",
   "time_zone": "America/Los_Angeles",
@@ -120,7 +120,7 @@ On January 7, 2019 we renamed Subscribers to People to better represent who you�
       <td>The subscriber's primary phone number.</td>
     </tr>
     <tr>
-      <td><code>sms_phone_number</code></td>
+      <td><code>sms_number</code></td>
       <td>The subscriber's mobile phone number in E.164 formatting.</td>
     </tr>
     <tr>
@@ -352,12 +352,12 @@ If you need to create or update a collection of subscribers at once, use our [ba
       <td>Optional. The subscriber's primary phone number.</td>
     </tr>
     <tr>
-      <td><code>sms_phone_number</code></td>
+      <td><code>sms_number</code></td>
       <td>Optional. String. The subscriber's mobile phone number in E.164 formatting. E.g. <code>"+16125551212"</code>. Only US-based numbers are supported at this time.</td>
     </tr>
     <tr>
       <td><code>sms_consent</code></td>
-      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>null</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
+      <td>Optional. Boolean. Required if <code>sms_number</code> is not <code>null</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
     </tr>
     <tr>
       <td><code>user_id</code></td>

--- a/source/includes/rest/_workflows.md
+++ b/source/includes/rest/_workflows.md
@@ -451,14 +451,6 @@ If the workflow is not active, the subscriber will not be added to the workflow.
       <td>Optional. The subscriber's primary phone number.</td>
     </tr>
     <tr>
-      <td><code>sms_phone_number</code></td>
-      <td>Optional. String. The subscriber's mobile phone number in E.164 formatting. E.g. <code>"+16125551212"</code>. Only US-based numbers are supported at this time.</td>
-    </tr>
-    <tr>
-      <td><code>sms_consent</code></td>
-      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>null</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
-    </tr>
-    <tr>
       <td><code>user_id</code></td>
       <td>Optional. A unique identifier for the user in your database, such as a primary key.</td>
     </tr>

--- a/source/includes/rest/_workflows.md
+++ b/source/includes/rest/_workflows.md
@@ -456,7 +456,7 @@ If the workflow is not active, the subscriber will not be added to the workflow.
     </tr>
     <tr>
       <td><code>sms_consent</code></td>
-      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>nil</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
+      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>null</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
     </tr>
     <tr>
       <td><code>user_id</code></td>

--- a/source/includes/rest/_workflows.md
+++ b/source/includes/rest/_workflows.md
@@ -451,6 +451,14 @@ If the workflow is not active, the subscriber will not be added to the workflow.
       <td>Optional. The subscriber's primary phone number.</td>
     </tr>
     <tr>
+      <td><code>sms_phone_number</code></td>
+      <td>Optional. String. The subscriber's mobile phone number in E.164 formatting. E.g. <code>"+16125551212"</code>. Only US-based numbers are supported at this time.</td>
+    </tr>
+    <tr>
+      <td><code>sms_consent</code></td>
+      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>nil</code>. <code>true</code> if the person has granted SMS consent; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
+    </tr>
+    <tr>
       <td><code>user_id</code></td>
       <td>Optional. A unique identifier for the user in your database, such as a primary key.</td>
     </tr>

--- a/source/includes/rest/_workflows.md
+++ b/source/includes/rest/_workflows.md
@@ -456,7 +456,7 @@ If the workflow is not active, the subscriber will not be added to the workflow.
     </tr>
     <tr>
       <td><code>sms_consent</code></td>
-      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>nil</code>. <code>true</code> if the person has granted SMS consent; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
+      <td>Optional. Boolean. Required if <code>sms_phone_number</code> is not <code>nil</code>. <code>true</code> if the person has granted consent to receive marketing and other communication via SMS; <code>false</code> otherwise. If you’re unsure whether or not you have gained legal SMS consent, check out our <a href="https://my.drip.com/docs/manual/sms/compliance-manage-sms-compliance">TCPA requirements article</a>.</td>
     </tr>
     <tr>
       <td><code>user_id</code></td>


### PR DESCRIPTION
Add two attributes to the public Subscriber model for the main /v2/:account_id/subscribers/* routes:
* `sms_number`
* `sms_consent`

We are intentionally leaving out the doc updates for the /campaigns/:campaign_id/subscribers routes.