### PR TITLE
Fix the shape of input to createUpdateSubscriber()

### DIFF
--- a/source/includes/rest/_subscribers.md
+++ b/source/includes/rest/_subscribers.md
@@ -243,13 +243,11 @@ end
 
 const client = require('drip-nodejs')({ token: YOUR_API_KEY, accountId: YOUR_ACCOUNT_ID });
 const payload = {
-  subscribers: [{
-    email: "john@acme.com",
-    time_zone: "America/Los_Angeles",
-    custom_fields: {
-      shirt_size: "Medium"
-    }
-  }]
+  email: "john@acme.com",
+  time_zone: "America/Los_Angeles",
+  custom_fields: {
+    shirt_size: "Medium"
+  }
 };
 
 client.createUpdateSubscriber(payload)


### PR DESCRIPTION
As documented in [this issue](https://github.com/DripEmail/drip-nodejs/issues/30) on the `drip-nodejs` repo, this part of the docs features an incorrect schema being submitted to `createUpdateSubscriber()`. This PR corrects it.

Unsure if this also needs to be fixed above for the cURL example.