### PR TITLE
SMS-668 Add /v2 to DELETE subscriber route

### DIFF
--- a/source/includes/rest/_subscribers.md
+++ b/source/includes/rest/_subscribers.md
@@ -785,7 +785,7 @@ client.deleteSubscriber(idOrEmail)
 
 ### HTTP Endpoint
 
-`DELETE /:account_id/subscribers/:id_or_email`
+`DELETE /v2/:account_id/subscribers/:id_or_email`
 
 ### Arguments
 

--- a/source/includes/rest/_tags.md
+++ b/source/includes/rest/_tags.md
@@ -216,7 +216,7 @@ client.removeSubscriberTag(email, tag)
 
 ### HTTP Endpoint
 
-`DELETE /:account_id/subscribers/:email/tags/:tag`
+`DELETE /v2/:account_id/subscribers/:email/tags/:tag`
 
 ### Arguments
 

--- a/source/includes/rest/_tags.md
+++ b/source/includes/rest/_tags.md
@@ -216,7 +216,7 @@ client.removeSubscriberTag(email, tag)
 
 ### HTTP Endpoint
 
-`DELETE /v2/:account_id/subscribers/:email/tags/:tag`
+`DELETE /:account_id/subscribers/:email/tags/:tag`
 
 ### Arguments
 


### PR DESCRIPTION
The route for deleting a subscriber uses `/v2`, but the docs don't show that.