### PR TITLE
Fix error with heredoc closing label thingy

### DIFF
--- a/source/includes/rest/_batch_api.md
+++ b/source/includes/rest/_batch_api.md
@@ -32,7 +32,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/subscribers/batches" \
       ]
     }]
   }
-  EOF
+EOF
 ```
 
 ```ruby
@@ -141,7 +141,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/unsubscribes/batches" \
       ]
     }]
   }
-  EOF
+EOF
 ```
 
 ```ruby
@@ -243,7 +243,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/subscribers/batches" \
       ]
     }]
   }
-  EOF
+EOF
 ```
 
 ```ruby
@@ -405,7 +405,7 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart/b
       }
     ]
   }
-  EOF
+EOF
 ```
 
 > Responds with a <code>202 Accepted</code> if successful. That means the server accepted the request and queued it for processing. The response includes a list of unique request_ids that can be used to check the status of the request later on:
@@ -598,7 +598,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/orders/batches" \
       ]
     }]
   }
-  EOF
+EOF
 ```
 
 > Responds with a `202 Accepted` response and an empty JSON response:
@@ -779,7 +779,7 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/order/
       }
     ]
   }
-  EOF
+EOF
 ```
 
 ```ruby
@@ -1030,7 +1030,7 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/produc
       }
     ]
   }
-  EOF
+EOF
 ```
 
 > Responds with a <code>202 Accepted</code> if successful. That means the server accepted the request and queued it for processing. The response includes a list of unique request_ids that can be used to check the status of the request later on:

--- a/source/includes/rest/_campaigns.md
+++ b/source/includes/rest/_campaigns.md
@@ -525,7 +525,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/campaigns/CAMPAIGN_ID/s
       }
     }]
   }
-  EOF
+EOF
 ```
 
 ```ruby

--- a/source/includes/rest/_events.md
+++ b/source/includes/rest/_events.md
@@ -20,7 +20,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/events" \
       "occurred_at": "2014-03-22T03:00:00Z"
     }]
   }
-  EOF
+EOF
 ```
 
 ```ruby

--- a/source/includes/rest/_orders.md
+++ b/source/includes/rest/_orders.md
@@ -530,7 +530,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/orders" \
         }]
     }]
   }
-  EOF
+EOF
 ```
 
 
@@ -856,7 +856,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/refunds" \
         "processed_at": "2013-06-22T10:41:11Z"
       }]
   }
-  EOF
+EOF
 ```
 
 ```ruby

--- a/source/includes/rest/_tags.md
+++ b/source/includes/rest/_tags.md
@@ -95,7 +95,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/tags" \
       "tag": "Customer"
     }]
   }
-  EOF
+EOF
 ```
 
 ```ruby

--- a/source/includes/rest/_webhooks.md
+++ b/source/includes/rest/_webhooks.md
@@ -209,7 +209,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/webhooks" \
       ]
     }]
   }
-  EOF
+EOF
 ```
 
 ```ruby

--- a/source/includes/rest/_workflows.md
+++ b/source/includes/rest/_workflows.md
@@ -330,7 +330,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/workflows/WORKFLOW_ID/s
       }
     }]
   }
-  EOF
+EOF
 ```
 
 ```ruby
@@ -631,7 +631,7 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/workflows/WORKFLOW_ID/t
       }
     ]
   }
-  EOF
+EOF
 ```
 
 ```ruby
@@ -752,7 +752,7 @@ curl -X PUT "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/workflows/WORKFLOW_ID/tr
       }
     ]
   }
-  EOF
+EOF
 ```
 
 ```ruby

--- a/source/includes/shopper_activity/_cart_activity.md
+++ b/source/includes/shopper_activity/_cart_activity.md
@@ -46,7 +46,7 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/cart" 
       }
     ]
   }
-  EOF
+EOF
 ```
 
 ```ruby

--- a/source/includes/shopper_activity/_order_activity.md
+++ b/source/includes/shopper_activity/_order_activity.md
@@ -82,7 +82,7 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/order"
       "phone": "555-555-5555"
     }
   }
-  EOF
+EOF
 ```
 
 ```ruby

--- a/source/includes/shopper_activity/_product_activity.md
+++ b/source/includes/shopper_activity/_product_activity.md
@@ -31,7 +31,7 @@ curl -X POST "https://api.getdrip.com/v3/YOUR_ACCOUNT_ID/shopper_activity/produc
     "product_url": "https://mysuperstore.com/dp/B01J4SWO1G",
     "image_url": "https://www.getdrip.com/images/example_products/water_bottle.png"
   }
-  EOF
+EOF
 ```
 
 ```ruby


### PR DESCRIPTION
When testing out https://github.com/DripEmail/drip/pull/23679, I spent an hour trying to figure out how to get the cURL command shown here to work: https://developer.drip.com/?shell#batch-api

I finally tried removing the indentation in front of the closing `EOF`, and the request went through.  Not the sort of experience we want to give our customers.

With the indentation:
```bash
$ curl -v -X POST "https://api-staging.getdrip.com/v2/7435085/subscribers/batches.json" \
  -H "Content-Type: application/json" \
  -H "User-Agent: http://test.grange.io/" \
  -u b41fade82d4b47fa127001d934544287: \
  -d @- << EOF
        {
    "batches": [{
      "subscribers": [
        {
          "email": "john-schmon@acme.com",
          "time_zone": "America/Los_Angeles",
          "tags": ["Customer", "SEO"],
          "custom_fields": {
            "shirt_size": "Medium"
          }
        },
        {
          "email": "joe@acme.com",
          "time_zone": "America/Los_Angeles",
          "tags": ["Prospect"],
          "custom_fields": {
            "shirt_size": "Medium"
          }
        }
      ]
    }]
  }
  EOF
heredoc> # I had to hit CTRL+c here to kill it
$ 
```
Without the indentation (apparently even github's markdown recognizes the difference; notice the color of the closing `EOF`):
```bash
$ curl -v -X POST "https://api-staging.getdrip.com/v2/7435085/subscribers/batches.json" \
  -H "Content-Type: application/json" \
  -H "User-Agent: http://test.grange.io/" \
  -u b41fade82d4b47fa127001d934544287: \
  -d @- << EOF
        {
    "batches": [{
      "subscribers": [
        {
          "email": "john-schmon@acme.com",
          "time_zone": "America/Los_Angeles",
          "tags": ["Customer", "SEO"],
          "custom_fields": {
            "shirt_size": "Medium"
          }
        },
        {
          "email": "joe@acme.com",
          "time_zone": "America/Los_Angeles",
          "tags": ["Prospect"],
          "custom_fields": {
            "shirt_size": "Medium"
          }
        }
      ]
    }]
  }
EOF
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 54.192.58.60:443...
* Connected to api-staging.getdrip.com (54.192.58.60) port 443 (#0)

[...omitting about 100 lines of output...]

* Connection #0 to host api-staging.getdrip.com left intact
{"message":"API rate limit exceeded. Please try again in an hour."}% # This response is expected, since I had already finished testing the rate limiting was working before grabbing this output
$ 
```