### PR TITLE
Remove `sort` from the CampaignSubscribers V2 endpoint

### DIFF
--- a/source/includes/rest/_campaigns.md
+++ b/source/includes/rest/_campaigns.md
@@ -456,7 +456,6 @@ client.listAllSubscribesToCampaign(campaignId)
   "links": { ... },
   "meta": {
     "page": 1,
-    "sort": "created_at",
     "direction": "desc",
     "count": 20,
     "total_pages": 1,
@@ -489,12 +488,8 @@ client.listAllSubscribesToCampaign(campaignId)
       <td>Optional. The page number. Defaults to <code>1</code>.</td>
     </tr>
     <tr>
-      <td><code>sort</code></td>
-      <td>Optional. The attribute by which to sort the results: <code>id</code> or <code>created_at</code>. Defaults to <code>created_at</code>.</td>
-    </tr>
-    <tr>
       <td><code>direction</code></td>
-      <td>Optional. The direction to sort the results: <code>asc</code> or <code>desc</code>. Defaults to <code>desc</code>.</td>
+      <td>Optional. The direction to sort the results for <code>created_at</code>: <code>asc</code> or <code>desc</code>. Defaults to <code>desc</code>.</td>
     </tr>
     <tr>
       <td><code>per_page</code></td>


### PR DESCRIPTION
## TL;DR

Due to this field not working and performance issues supporting it today
it was decided to remove it from the official documentation.

## Background

`sort` and `direction` on this endpoint have been broken for a long
time. Once we found out, direction was determined fixable at this time.
Unfortunatly, sort was not.