### PR TITLE
Also fix `cURL` example code

### DIFF
--- a/source/includes/rest/_events.md
+++ b/source/includes/rest/_events.md
@@ -11,14 +11,12 @@ curl -X POST "https://api.getdrip.com/v2/YOUR_ACCOUNT_ID/events" \
   -u YOUR_API_KEY: \
   -d @- << EOF
   {
-    "events": [{
-      "email": "john@acme.com",
-      "action": "Logged in",
-      "properties": {
-        "affiliate_code": "XYZ"
-      },
-      "occurred_at": "2014-03-22T03:00:00Z"
-    }]
+    "email": "john@acme.com",
+    "action": "Logged in",
+    "properties": {
+      "affiliate_code": "XYZ"
+    },
+    "occurred_at": "2014-03-22T03:00:00Z"
   }
 EOF
 ```


### PR DESCRIPTION
Same fix as here but for `cURL` instead of JS: https://github.com/DripEmail/api-docs/pull/110

Looks good locally