### PR TITLE
Update Order price documentation

### DIFF
--- a/source/includes/shopper_activity/_order_activity.md
+++ b/source/includes/shopper_activity/_order_activity.md
@@ -292,7 +292,7 @@ end
             </tr>
             <tr>
               <td><code>price</code></td>
-              <td>Required. The price of a single product.</td>
+              <td>Optional. The price of a single product. Note that products without prices will be unavailable for segmentation by purchase price.</td>
             </tr>
             <tr>
               <td><code>quantity</code></td>


### PR DESCRIPTION
Addresses issues discussed in [this slack conversation](https://getdrip.slack.com/archives/C7M0K5Z8D/p1684860491695529)

We do not, in fact, require a price on order items going to SA. This can lead to the slightly confusing situation where we get items in the product catalog via an Order, but can't segment on purchase price.

Updated the docs to clarify that `price` is optional, but necessary for segmentation.