### PR TITLE
Fix broken link in cart activity docs

### DIFF
--- a/source/includes/shopper_activity/_cart_activity.md
+++ b/source/includes/shopper_activity/_cart_activity.md
@@ -2,7 +2,7 @@
 
 Passing in all required fields for Cart Activity will enable Cart Abandonment Dynamic Content in your Drip account. Leverage that content in our Visual Email Builder to send Cart Abandonment emails containing item details.
 
-Note that Cart Activity will show up on a person's activity timeline as either a "Created a cart" or "Updated a cart" event. For more information, see our guide in MyDrip [here](https://www.drip.com/learn/docs/guides/report-revenue).
+Note that Cart Activity will show up on a person's activity timeline as either a "Created a cart" or "Updated a cart" event. For more information, see our help center article [here](https://help.drip.com/hc/en-us/articles/4424695494541-Install-a-Shareable-Cart-Abandonment-Workflow-Using-the-Shopper-Activity-API).
 
 ## Create or update a cart
 


### PR DESCRIPTION
## Change

Fixes a broken link on the developer.drip.com cart activity page.

The link previously pointed to `https://www.drip.com/learn/docs/guides/report-revenue` (an old URL that no longer works). Updated to point to the current help center article, and updated the surrounding text to remove the outdated "in MyDrip" phrasing.

### Slack thread

https://getdrip.slack.com/archives/C045YMJ143A/p1771889215126299

